### PR TITLE
Headers investigation and fix

### DIFF
--- a/Archive/20250218 Overview m_wrap/README.md
+++ b/Archive/20250218 Overview m_wrap/README.md
@@ -5,3 +5,29 @@ namely, with the specific goal of not having to read through the entire file
 twice if avoidable.  
 Reading the file twice usually occurs in the case where there is a need to
 determine the m-offsets midway through the file.
+
+## Results
+
+We exclude the printing of None length data due to the fact that it is fairly
+challenging to go through all of them to see which of the anomalous data sets
+is creating such large values. Nonetheless, the data as it is can still be
+opened manually as it is a csv. Aternatively, the csv can be viewed in the
+command line with
+```
+  column -t -s ',' --output-width 25 summarized_headers.csv | bat --wrap never
+```
+where the use of the `head` command and related can help keep the total number
+of rows restricted. (The output-width flag might not be the flag we want?.)
+
+Unsurprisingly, files listed as being 20km had the largest mean.
+However, some of the 1km data
+
+```
+  length         maximum ratio            ratio             std_dev(ratio)
+l =   1km, max = 0.000026207035, r = 0.000000150844, e = 1.69743632772515e-06
+l =  20km, max = 0.000029440955, r = 0.000005045825, e = 7.1735575390297466e-06
+l =  500m, max = 0.000002919202, r = 0.000000417029, e = 1.0215079483756529e-06
+l =   0km, max = 0.000040693627, r = 0.000000446586, e = 3.7241364229580563e-06
+```
+
+A second round of revision might be necessary to fish out Cintech data.

--- a/Archive/20250218 Overview m_wrap/README.md
+++ b/Archive/20250218 Overview m_wrap/README.md
@@ -1,0 +1,7 @@
+# Investigate necessary header space for _sparse_m_delta array
+
+Currently, in the midst of specifying requirements in VHF bin files' headers,
+namely, with the specific goal of not having to read through the entire file
+twice if avoidable.  
+Reading the file twice usually occurs in the case where there is a need to
+determine the m-offsets midway through the file.

--- a/Archive/20250218 Overview m_wrap/summarise_all_headers.py
+++ b/Archive/20250218 Overview m_wrap/summarise_all_headers.py
@@ -1,0 +1,176 @@
+import csv
+import logging
+from logging import getLogger
+from multiprocessing import cpu_count, Lock, Pool
+from multiprocessing import current_process as current_proc
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable
+module_path = str(Path(__file__).parents[2])
+if module_path not in sys.path:
+    sys.path.append(module_path)
+from VHF.parse import VHFparser
+
+
+find_files_process = subprocess.check_output(["fd", "-tfile", "-E", r"'**/*{tmp,test}*'", "--extension", "bin", ".", "/mnt/nas-fibre-sensing"])
+BASE_PATH = Path(__file__).parent
+REGEX_LEN_FROM_STR = re.compile(r"[\._\/\-\:\_]{1}(?P<leng>\d{1,}k?m)[\._\/\-\:\_]{1}")  # ?P<name> notation is? Python specific
+SEARCH_FILES = set(map(Path, find_files_process.decode().split("\n")))
+SUMMARY_FILE = BASE_PATH.joinpath("summarized_headers.csv")
+CSV_FIELDS = ["path", "fibre_length", "num_samples", "sparse_m_delta_length", "str_sparse_m_delta", "str_sparse_m_delta_idx"]
+
+
+def init_pool_processes(the_lock):
+    """Initialize each process with a global variable lock."""
+    global lock
+    lock = the_lock
+
+
+def worker(file: Path):
+    """Currently, we demand that workers can only take 1 arg for imap."""
+    logger.info("worker called with args: %s", file)
+    parser = None
+
+    try:
+        parser = fetch_out_parser(file)
+    except Exception as exc:
+        logger.critical("exc= %s", exc)
+        logger.critical("", exc_info=True)
+        return
+
+    csv_write(parser)
+    return
+
+
+def fetch_out_parser(fname: Path) -> VHFparser:
+    result = VHFparser(
+        fname, headers_only=True,  # plot_duration=timedelta(seconds=0.1)
+    )
+    result._pre_trace_parsing()
+    return result
+
+
+def get_bin_files() -> set[Path]:
+    """Determine which binary files left are required to be read."""
+    all_files = SEARCH_FILES
+    with open(SUMMARY_FILE, 'r', newline='') as file:
+        paths = csv.DictReader(file)  # use default Excel dialect
+        already_read: set[Path] = set(Path(x[CSV_FIELDS[0]]) for x in paths)
+
+    return all_files - already_read
+
+
+def fibre_len_from_file_name(filename: str) -> str:
+    """
+    From file basename, make a best effort deduction on what the length was.
+    """
+    result = REGEX_LEN_FROM_STR.search(filename)
+    if result is None:
+        return "None"
+    else:
+        return result.group("leng")  # This comes from REGEX_LEN_FROM_STR
+
+
+def csv_write(parsed: VHFparser):
+    """Takes the data pulled out from the files for specified time and writes into csv file."""
+    full_path: Path = parsed._filename
+    fibre_length = fibre_len_from_file_name(str(full_path.resolve()))
+    num_samples = parsed._num_trc_bytes
+    sparse_m_delta_length = 0 if parsed._m_mgr is None else len(parsed._m_mgr.sparse_m_delta)
+    sparse_m_delta_str = None if sparse_m_delta_length == 0 else str(parsed._m_mgr.sparse_m_delta).replace("\r", "").replace("\n", "")
+    sparse_m_delta_idx_str = None if sparse_m_delta_length == 0 else str(parsed._m_mgr.sparse_m_delta_idx).replace("\r", "").replace("\n", "")
+
+    row = {
+        CSV_FIELDS[0]: full_path,
+        CSV_FIELDS[1]: fibre_length,
+        CSV_FIELDS[2]: num_samples,
+        CSV_FIELDS[3]: sparse_m_delta_length,
+        CSV_FIELDS[4]: sparse_m_delta_str,
+        CSV_FIELDS[5]: sparse_m_delta_idx_str,
+    }
+
+    try:
+        with lock:
+            logger.debug("%s acquired lock", current_proc().name)
+            csv_write_core(row)
+    except NameError:  # we are not in multiproc mode and have no lock
+        csv_write_core(row)
+
+
+def csv_write_core(row_write: dict):
+    with open(SUMMARY_FILE, 'a') as file:
+        dict_write = csv.DictWriter(file, fieldnames=CSV_FIELDS)
+        dict_write.writerow(row_write)
+        logger.info("%s Save done", current_proc().name)
+
+
+def main():
+    """Perform digesting of files to obtain length of sparse_m_delta."""
+    files_left: Iterable[Path] = get_bin_files()
+    logger.info("Running for %d files left.", len(files_left))
+
+    csv_lock = Lock()
+    nproc = cpu_count() - 1
+    with Pool(processes=nproc, initializer=init_pool_processes, initargs=(csv_lock,)) as pool:
+        p = pool.imap_unordered(
+            worker,
+            files_left
+        )
+        _ = list(p)  # we need something to iteratively consume up the imap to drive the pool
+
+
+def main_linear():
+    """Perform digesting of files down for length of sparse_m_delta without Pool."""
+    logger.info("Now running for %d", len(SEARCH_FILES))
+    files_left: Iterable[Path] = get_bin_files()
+
+    for f in files_left:
+        worker(f)
+
+
+def create_summary_file():
+    """Creates summary file"""
+    if SUMMARY_FILE.exists():
+        logger.info("summary file already exists. skipping...")
+        return
+    with open(SUMMARY_FILE, 'w+') as file:
+        d_writer = csv.DictWriter(file, fieldnames=CSV_FIELDS)
+        d_writer.writeheader()
+
+
+if __name__ == "__main__":
+    logger = getLogger()
+    logger.setLevel(logging.DEBUG)
+    filehandler = logging.FileHandler("summarise_all_headers_log.txt")
+    filehandler.setLevel(logging.INFO)
+    streamhandler = logging.StreamHandler(sys.stdout)
+    streamhandler.setLevel(logging.INFO)
+    fmtter = logging.Formatter(
+        # the current datefmt str discards date information
+        '[%(asctime)s.%(msecs)03d] (%(levelname)s) %(processName)s:%(threadName)s:%(name)s: \t%(message)s',
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    filehandler.setFormatter(fmtter)
+    streamhandler.setFormatter(fmtter)
+    logger.addHandler(filehandler)
+    logger.addHandler(streamhandler)
+
+    if len(SEARCH_FILES) == 0:
+        logger.error("Files not found! Cannot proceed!")
+        sys.exit(1)
+
+    if not SUMMARY_FILE.exists():
+        logger.info("CSV Summary File could not be found, creating.")
+        create_summary_file()
+        proceed: bool = True
+    else:
+        logger.warning("CSV Summary file found. Append?")
+        proceed: bool = input("Existing CSV Summary File found... Append? [y/N] ").upper() != 'N'
+
+    logger.info("SEARCH_FILES.len = %d", len(SEARCH_FILES))
+
+    if proceed:
+        main()
+        # main_linear()

--- a/Archive/20250218 Overview m_wrap/view_headers.py
+++ b/Archive/20250218 Overview m_wrap/view_headers.py
@@ -1,0 +1,106 @@
+import csv
+from matplotlib import pyplot as plt
+import numpy as np
+from numpy.typing import NDArray
+from pathlib import Path
+from summarise_all_headers import CSV_FIELDS
+
+BASE_PATH = Path(__file__).parent
+SUMMARY_FILE_OLD = BASE_PATH.joinpath("summarized_headers.csv.bak")
+SUMMARY_FILE = BASE_PATH.joinpath("summarized_headers.csv")
+FIELDS_WITH_TYPE = list(zip(CSV_FIELDS, ["U200", "U10", "<i8", "<i8", "U", "U"]))
+# FIELDS_WITH_TYPE = "U, U, <i8, <i8, U, U"
+
+
+def data_from_backup():
+    with open(SUMMARY_FILE_OLD, 'r') as file:
+        d_reader = csv.DictReader(file, fieldnames=CSV_FIELDS)
+        result = [row for row in d_reader]
+        result.pop(0)  # Remove header
+        return result
+
+
+def data_from_backup_as_array() -> NDArray:
+    """Read into a numpy array."""
+    with open(SUMMARY_FILE, 'r') as file:
+        len_d_reader = len(file.readlines()) - 1
+
+    with open(SUMMARY_FILE, 'r') as file:
+        d_reader = csv.DictReader(file, fieldnames=CSV_FIELDS)
+        result = np.zeros(
+            (len_d_reader,),
+            dtype=FIELDS_WITH_TYPE
+        )
+        for i, row in enumerate(d_reader):
+            if i == 0:  # Remove header
+                continue
+            result[i-1] = np.array(
+                tuple(row.values()),
+                dtype=FIELDS_WITH_TYPE
+            )
+
+        return result
+
+
+def plot_data(data: NDArray):
+    """With dict_reader data, we now see the number of data points by ratio."""
+    # Raw
+    x_raw = np.fromiter(map(lambda x: x[1], data), dtype=FIELDS_WITH_TYPE[1][1])
+    ratio = np.fromiter(map(lambda x: x[3]/x[2], data), dtype=np.float64)
+
+    x = {"None", "0km", "500m", "1km", "20km"}
+    x_raw_set = set(x_raw)
+    if x_raw_set - x:
+        print("Error! Data in csv contains fibre lengths not expected.")
+        return
+
+    heights = {}
+    for key in x:
+        heights[key] = (
+            ratio[np.where(x_raw == key)].mean(),
+            ratio[np.where(x_raw == key)].std(),
+            ratio[np.where(x_raw == key)].max(),
+        )
+    x = tuple([k for k in x if k != "None"])
+    print(f"{x = }")
+    height = tuple(heights[k][0] for k in x if k != "None")
+    error = tuple(heights[k][1] for k in x if k != "None")
+    max = tuple(heights[k][2] for k in x if k != "None")
+
+    for k, m, r, e in zip(x, max, height, error):
+        print(f"l = {k:>7s}, max = {m:>5.12f}, r = {r:>5.12f}, {e = }")
+
+    # Plot
+    fig, ax = plt.subplots(nrows=1, ncols=1)
+
+    ax.bar(x, height)
+    ax.errorbar(x, height, error)
+
+    plt.show(block=True)
+    return
+
+
+def clean_and_sort_csv():
+    data = data_from_backup()
+    data.sort(key=lambda x: x[CSV_FIELDS[0]])
+
+    with open(SUMMARY_FILE, 'w') as csv_file:
+        d_writer = csv.DictWriter(csv_file, fieldnames=CSV_FIELDS)
+        d_writer.writeheader()
+        d_writer.writerows(data)
+
+    return
+
+
+def plot_csv():
+    data = data_from_backup_as_array()
+    plot_data(data)
+
+
+def main():
+    clean_and_sort_csv()
+    plot_csv()
+
+
+if __name__ == "__main__":
+    main()

--- a/VHF/parse.py
+++ b/VHF/parse.py
@@ -642,7 +642,14 @@ class VHFparser:
             print("No file-like/buffer object given to init.")
             return
         self._init_timing_info()
-        assert self._num_trc_bytes == self.timings.duration_idx
+        try:
+            assert self._num_trc_bytes == self.timings.duration_idx
+        except AssertionError:
+            self.logger.error(
+                "_num_trc_bytes = %d != timings.duration_idx = %d",
+                self._num_trc_bytes, self.timings.duration_idx
+            )
+        assert abs(self._num_trc_bytes - self.timings.duration_idx) <= 1
 
         # init guard: parse time params
         if plot_start_time is not None:

--- a/VHF/parse.py
+++ b/VHF/parse.py
@@ -127,9 +127,9 @@ class TraceTimer:
             raise ValueError("trace_freq cannot be created by VHF board; Skip parameter was fractional?")
 
         self.trace_start = trace_start
-        self._trace_start_ns = int(self._dt_to_ns(trace_start))
+        self._trace_start_ns = self._dt_to_ns(trace_start)
         self.trace_duration = timedelta(microseconds=1e6*trace_size/trace_freq)
-        self._trace_duration_ns = int(1e9*trace_size/trace_freq)
+        self._trace_duration_ns = self._to_int(1e9*trace_size/trace_freq)
         self.sample_interval = timedelta(microseconds=1e6/trace_freq)  # this is still fallible
         self._sample_interval_ns: float = 1e9/trace_freq
         self.trace_end = self.trace_start + self.trace_duration
@@ -276,11 +276,16 @@ class TraceTimer:
 
         return start_changed or end_changed
 
+    def _to_int(self, x: float) -> int:
+        result = int(np.rint(x))
+        assert np.isclose(result, x), "Something terrible has gone wrong."
+        return result
+
     def _dt_to_ns(self, t: datetime) -> int:
         """From datetime.datetime to number of ns from some t=0."""
         # We shouldn't be needing to check for fractional components despite
         # timestamp being a float.
-        return int(t.timestamp() * 1_000_000_000)
+        return self._to_int(t.timestamp() * 1_000_000_000)
 
     def _datetime_aware(self, dt: datetime) -> bool:
         """Determine if a datetime object is aware, or otherwise (naive)."""
@@ -312,13 +317,13 @@ class TraceTimer:
     @property
     def trace_duration_idx(self) -> int:
         """Length of trace"""
-        return int(self._trace_duration_ns/self._sample_interval_ns)
+        return self._to_int(self._trace_duration_ns/self._sample_interval_ns)
 
     @property
     def start_idx(self) -> int:
         """Start index of plot window relative to trace[0] for plot_start."""
         delta = self._plot_start_ns - self._trace_start_ns
-        return int(delta/self._sample_interval_ns)
+        return self._to_int(delta/self._sample_interval_ns)
 
     @property
     def end_idx(self) -> int:
@@ -329,7 +334,7 @@ class TraceTimer:
     def duration_idx(self) -> int:
         """Duration index of plot window specifying number of bytes to read."""
         delta = self._plot_end_ns - self._plot_start_ns
-        return int(delta/self._sample_interval_ns)
+        return self._to_int(delta/self._sample_interval_ns)
 
 
 class ManifoldRollover:

--- a/VHF/parse.py
+++ b/VHF/parse.py
@@ -120,9 +120,9 @@ class TraceTimer:
         """
         self.logger = logging.getLogger("vhfparser")
 
-        if trace_freq > 1e7:
+        if trace_freq > 10_000_000:
             raise ValueError("trace_freq cannot be created by VHF board")
-        tmp = int(tmp2 := (2e7/trace_freq))
+        tmp = int(tmp2 := (20_000_000/trace_freq))
         if tmp != tmp2:
             raise ValueError("trace_freq cannot be created by VHF board; Skip parameter was fractional?")
 
@@ -280,7 +280,7 @@ class TraceTimer:
         """From datetime.datetime to number of ns from some t=0."""
         # We shouldn't be needing to check for fractional components despite
         # timestamp being a float.
-        return int(t.timestamp() * 1e9)
+        return int(t.timestamp() * 1_000_000_000)
 
     def _datetime_aware(self, dt: datetime) -> bool:
         """Determine if a datetime object is aware, or otherwise (naive)."""


### PR DESCRIPTION
Original goal associated with this branch was to determine what is a reasonable
amount of space necessary between the original header and the originally
intended data start point to allow for a one-pass instead of two-pass read of
the entire binary data file.

Whilst doing so, it had became apparent that there were still quite a sizeable
number of files which broke some of the assumptions that were being checked
through assertions in the code. A class of these files which broke the
assertion was the consequence of float rounding associated with the file
length, which resulted in increased floating imprecision for very large files.

This fix has been tested against every otherwise compliant file, and there is
no file at the moment that current has TraceTimer behave poorly.
There are some files which have UnicodeDecodeerror in the HeaderParser,
among a few other issues.
