### PR TITLE
Improve performance of stream

### DIFF
--- a/VHF-rs/Cargo.toml
+++ b/VHF-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "VHF"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "stream"

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -44,7 +44,7 @@ pub(super) struct MMapReader {
     prev_bytes: usize,
     /// Time for a single page.
     page_duration: Duration,
-    /// Time between stream wakeups
+    /// Time between stream ([<super::VHFIter>::next] method) wakeups
     stream_pause: Duration,
     /// Maximal amount of time alloweable waiting for parent thread to unpark before self unpark.
     loop_timeout: Duration,
@@ -80,6 +80,8 @@ impl MMapReader {
                 .unwrap())
         .try_into()
         .map_err(Error::Jiff)?;
+        log::debug!("mmap_reader thread loop_timeout = {:?}", loop_timeout);
+
         Ok(Self {
             handle,
             mmap,
@@ -132,10 +134,11 @@ impl MMapReader {
     /// [super::VHF::ioctl_next] yields Err or has negative value.
     fn stream(&mut self) -> Result<()> {
         let mut next_bytes;
-        let mut time_after_mmap_fetch;
         loop {
             // If the current time has exceed the next expected fetch time, then proceed, else sleep.
+            log::trace!("mmap_reader thread park");
             thread::park_timeout(self.loop_timeout); // May apparently spuriously wake.
+            log::trace!("mmap_reader thread unpark");
 
             // Pull out from Mmap and place into heap
             'next_mmap: loop {
@@ -144,18 +147,23 @@ impl MMapReader {
                     return Err(Error::ioctl_call("Negative next value received."));
                 }
                 if next.wrapping_sub(self.last_tfb32) <= (1 << ALIGN_VHF_OUTPUT_TO_PAGES) {
-                    log::trace!("tried getting next before having more than a page of data...");
-                    log::trace!("last_tfb32 = {}, next = {}", self.last_tfb32, next);
                     thread::park_timeout(self.page_duration);
-                    continue;
-                }
+                    continue 'next_mmap;
+                };
 
                 // Enough pages have accumulated.
                 let offset = (next as usize % MMAP_BYTES_LEN) >> ALIGN_VHF_OUTPUT_TO_PAGES
                     << ALIGN_VHF_OUTPUT_TO_PAGES;
                 self.last_tfb32 = next;
                 next_bytes = offset;
-                time_after_mmap_fetch = Instant::now();
+                let time_after_mmap_fetch = Instant::now();
+
+                // Set next wake time, because pushing onto buffer does take a while.
+                {
+                    let mut to_write = self.next_collect_time.write().unwrap();
+                    *to_write = time_after_mmap_fetch + self.stream_pause;
+                }
+
                 break 'next_mmap;
             }
 
@@ -164,7 +172,10 @@ impl MMapReader {
             // long.)
             'push_back: loop {
                 match self.transfer_buffer.try_lock() {
-                    Err(_) => spin_loop(),
+                    Err(_) => {
+                        log::trace!("could not get buffer for pushing onto page");
+                        spin_loop(); // This is a no-op on x86;
+                    }
                     Ok(mut inner) => {
                         use itertools::Itertools;
 
@@ -182,22 +193,16 @@ impl MMapReader {
                             });
 
                         // Update counter
-                        log::trace!(
-                            "next_bytes = {}, prev_bytes = {}",
-                            next_bytes,
-                            self.prev_bytes
-                        );
-
                         self.collected_pages += num_pages;
                         self.prev_bytes = next_bytes;
 
                         // Signal back to parent thread that pages have been placed in.
                         self.transfer_buffer_signal.notify_all();
 
-                        // Set next wake time
+                        // Set next wake time again
                         {
                             let mut to_write = self.next_collect_time.write().unwrap();
-                            *to_write = time_after_mmap_fetch + self.stream_pause;
+                            *to_write = Instant::now() + self.stream_pause;
                         }
 
                         break 'push_back;

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -397,7 +397,10 @@ impl<'a> std::iter::Iterator for VHFIter<'a> {
                     let _ = buf.pop_front();
                     return Some((idx, arr));
                 }
-            }
+            } else if self.buffer.is_poisoned() {
+                panic!("MMapReader thread has panicked");
+            }; // We do nothing even if buffer was not locked: Child thread might still be pushing
+               // into it.
 
             // Early break - Engine is not running anymore for any reason (Thread panic perhaps?)
             if !self

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -82,6 +82,7 @@ impl VHF {
         assert_eq!(config.stream_fold_parameters(), params);
 
         let time_between_pages: Span = pages::time_between_pages_in_ns(&config.speed)?;
+        log::debug!("Time between pages = {}", time_between_pages);
 
         let wake_mmap = Arc::new(RwLock::new(Instant::now()));
 
@@ -115,12 +116,16 @@ impl VHF {
             let engine_running = engine_running.clone();
             let buffer_signal = buffer_signal.clone();
             let buffer = buffer.clone();
-            let time_between_stream_resume =
-                ((TryInto::<i64>::try_into(VHF_MMAP_WINDOW_LEN).unwrap() - 4)
-                // Hardcoded for now... should be determined by config
+            let number_of_pages_between_stream_resume = (VHF_MMAP_WINDOW_LEN as i64 - 4) * 3;
+            let time_between_stream_resume = (number_of_pages_between_stream_resume
                 * time_between_pages)
-                    .try_into()
-                    .map_err(Error::Jiff)?;
+                .try_into()
+                .map_err(Error::Jiff)?;
+            debug_assert!(number_of_pages_between_stream_resume < DEQUE_CAP as i64 / 2);
+            log::debug!(
+                "MMapReader time_between_stream_resume = {:?}",
+                time_between_stream_resume
+            );
             let next_collect_time = wake_mmap.clone();
             let streamfold = params.clone();
             thread::Builder::new()
@@ -334,6 +339,7 @@ pub struct VHFIter<'a> {
 impl<'a> WakeMapReader for VHFIter<'a> {
     /// Wake MMapReader child thread.
     fn unpark_child(&self) {
+        log::trace!("Unparking MmapReader thread");
         self.map_reader.thread().unpark()
     }
 }
@@ -356,6 +362,10 @@ impl<'a> std::iter::Iterator for VHFIter<'a> {
     // context).
     // The body page's index in the window has yet to be decided as being coordinated between the
     // Transform generator and this VHF, or if should be passed as a parameter.
+    //
+    // Note!: Buffer cannot be wrapped in a condvar, as it would block the next method. Condvar
+    // wrapping is acceptable only if condvar notify occurs on average at least once per page
+    // pushed onto the buffer.
     //
     // This method should be responsible for only moving the window forward by one.
     // ?: Anything that calls into VHF.next() should be using .step_by() before passing to the
@@ -394,7 +404,6 @@ impl<'a> std::iter::Iterator for VHFIter<'a> {
                 .engine_running
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
-                // TODO: Pad as necessary with Empty end for par_map?
                 return None;
             };
 
@@ -403,19 +412,33 @@ impl<'a> std::iter::Iterator for VHFIter<'a> {
             // 1. Condvar activated or
             // 2. We self check that the current instant exceeds the time as a last measure.
 
-            while Instant::now() < *self.wake_mmap.read().unwrap() {
-                let timeout = self
-                    .buffer_signal
-                    .wait_timeout(mg.lock().unwrap(), time_between_pages)
-                    .unwrap();
-                if !timeout.1.timed_out() {
-                    continue 'get_page;
-                }
-                continue;
-            }
+            'get_wake: loop {
+                if let Ok(target_wakeup) = self.wake_mmap.read() {
+                    let target_wakeup = *target_wakeup;
 
-            if Instant::now() >= *self.wake_mmap.read().unwrap() {
-                self.unpark_child()
+                    let now = Instant::now();
+                    if now < target_wakeup {
+                        let sleep_for = target_wakeup.saturating_duration_since(now);
+                        thread::sleep(sleep_for);
+
+                        // Wait 1 page of time for condvar
+                        let timeout = self
+                            .buffer_signal
+                            .wait_timeout(mg.lock().unwrap(), time_between_pages)
+                            .unwrap();
+                        if !timeout.1.timed_out() {
+                            // Forcibly try to get a page
+                            log::trace!("Cond_var timedout");
+                            continue 'get_page;
+                        }
+                        // The intended amount of thread::sleep has been performed.
+                        // Fall through as if now > target_wakeup
+                    }
+                    self.unpark_child();
+                    break 'get_wake;
+                } else {
+                    continue 'get_wake;
+                }
             }
         }
     }


### PR DESCRIPTION
Too much `Instant::now()` hot loop led to 200% CPU usage. Fall-through and sleep more often.

Parent thread might not be waking enough, increment as necessary. Observing in the mean time.