### PR TITLE
Fix streaming for more than i32::MAX number of elements

### DIFF
--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -260,8 +260,8 @@ impl Configs {
         result.push("-s".to_string());
         result.push(self.skip_num.to_string());
 
-        result.push("-".to_string() + &self.speed.to_string());
-        result.push("-".to_string() + &self.encode.to_string());
+        result.push("-".to_string() + &self.speed.to_char());
+        result.push("-".to_string() + &self.encode.to_char());
 
         if let Some(filter_const) = self.filter_const {
             result.push("-F".to_string());

--- a/VHF-rs/src/runner/config/mod.rs
+++ b/VHF-rs/src/runner/config/mod.rs
@@ -213,7 +213,7 @@ impl Configs {
 
     /// Checks if configuration has tripped anything. Errors only if warnings have been emitted.
     fn validate_config(&self) -> Result<()> {
-        if self.skip_num + 1 < 10 {
+        if self.skip_num + 1 < 5 {
             log::warn!("Received skip_num less than 10! byte alignment has known to break!");
             return Err(Error::ini_coerce("Board", "skip_num", "less than 10"));
         }

--- a/VHF-rs/src/runner/config/typedef.rs
+++ b/VHF-rs/src/runner/config/typedef.rs
@@ -51,6 +51,14 @@ impl SamplingSpeed {
             SamplingSpeed::Low => jiff::Span::new().nanoseconds(100),
         }
     }
+
+    /// This is for being in the header
+    pub(crate) fn to_char(&self) -> &str {
+        match self {
+            SamplingSpeed::High => &"h",
+            SamplingSpeed::Low => &"l",
+        }
+    }
 }
 
 /// The structure of the file saved.
@@ -85,6 +93,16 @@ impl FromStr for Encode {
             v => Err(Error::ParseUnrecognised(format!(
                 "Encode::try_from got value: {v}"
             ))),
+        }
+    }
+}
+
+impl Encode {
+    pub(crate) fn to_char(&self) -> &str {
+        match self {
+            Self::Binary => &"b",
+            Self::Hexadecimal => &"x",
+            Self::ASCII => &"t",
         }
     }
 }

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -281,6 +281,8 @@ impl core::ops::Drop for MMapReader {
                     self.collected_pages
                 );
                 log::error!("MMapReader = {self:?}");
+                log::error!("Forcing cleanup.");
+                let _ = self.close();
             }
             false => log::info!("MMapReader has been dropped."),
         }

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 /// Bottom 12 bytes of [super::board_ioctl_consts::ioctl_read] should be zero'd to align to [MmapPage::Page].
 pub const ALIGN_VHF_OUTPUT_TO_PAGES: usize = 9 + 3;
 
+#[derive(Debug)]
 pub(super) struct MMapReader {
     // FileHandle associated to mmap is needed to ioctl_next;
     handle: libc::c_int,
@@ -274,10 +275,13 @@ impl MMapReader {
 impl core::ops::Drop for MMapReader {
     fn drop(&mut self) {
         match thread::panicking() {
-            true => log::error!(
-                "MmapReader panicking! Had pushed {} pages.",
-                self.collected_pages
-            ),
+            true => {
+                log::error!(
+                    "MMapReader panicking! Had pushed {} pages.",
+                    self.collected_pages
+                );
+                log::error!("MMapReader = {self:?}");
+            }
             false => log::info!("MMapReader has been dropped."),
         }
     }

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -147,9 +147,14 @@ impl MMapReader {
                     log::error!("Received negative next value.");
                     return Err(Error::ioctl_call("Negative next value received."));
                 }
-                if next.wrapping_sub(self.last_tfb32) <= (1 << ALIGN_VHF_OUTPUT_TO_PAGES) {
+                if next.wrapping_sub(self.last_tfb32) & i32::MAX <= (1 << ALIGN_VHF_OUTPUT_TO_PAGES)
+                {
                     thread::park_timeout(self.page_duration);
                     continue 'next_mmap;
+                };
+                if next.wrapping_sub(self.last_tfb32) & i32::MAX > (MMAP_BYTES_LEN as i32) {
+                    log::error!("Circular buffer has already been overwritten!");
+                    return Err(Error::InternalInconsistency);
                 };
 
                 // Enough pages have accumulated.

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -6,6 +6,7 @@ mod mmap_reader;
 pub(super) mod pages;
 
 use super::Config;
+use super::config::typedef::SamplingSpeed;
 use super::fold::StreamFold;
 use crate::{Error, Result};
 use consts::{MMAP_PAGE_LEN, VHF_MMAP_WINDOW_LEN};
@@ -219,8 +220,18 @@ impl VHF {
             std::thread::sleep(std::time::Duration::from_nanos(2000)); // 1000 might be sufficient
 
             buf_write
-                .write(format!("config 16; param {};", config.filter_const.unwrap_or(0)).as_bytes())
-                .map_err(Error::Io)?; // filter_const
+                .write(
+                    format!("config 16; param {};", {
+                        // Default is 0
+                        let fc = config.filter_const.unwrap_or(0);
+                        match config.speed {
+                            SamplingSpeed::Low => (fc << 1) | 1,
+                            SamplingSpeed::High => (fc << 1) & !1,
+                        }
+                    })
+                    .as_bytes(),
+                )
+                .map_err(Error::Io)?; // filter_const + fast/slow
             buf_write
                 .write(format!("config 1; param {};", config.skip_num).as_bytes())
                 .map_err(Error::Io)?; // skips samples

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -365,6 +365,7 @@ impl std::iter::Iterator for VHFIter<'_> {
     // transformer.
     fn next(&mut self) -> Option<Self::Item> {
         if self.windows_released > self.total_pages_to_read.into() {
+            log::debug!("next yielding none: Released enough windows.");
             return None;
         }
 
@@ -400,6 +401,7 @@ impl std::iter::Iterator for VHFIter<'_> {
                 .engine_running
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
+                log::debug!("next yielding none: engine stopped running.");
                 return None;
             };
 

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -227,9 +227,6 @@ impl VHF {
             buf_write
                 .write(format!("config 2; param {};", config.gain.unwrap_or(0)).as_bytes())
                 .map_err(Error::Io)?; // Gain parameter
-            buf_write
-                .write(format!("config 3; param {};", config.gain.unwrap_or(0)).as_bytes())
-                .map_err(Error::Io)?; // Gain parameter
             buf_write.write(b"config 3; param 0;").map_err(Error::Io)?; // debug param = 0
             buf_write.write(b"skip; skip;").map_err(Error::Io).unwrap();
             buf_write.flush().map_err(Error::Io)?;

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -305,6 +305,19 @@ impl VHF {
     }
 }
 
+impl Drop for VHF {
+    fn drop(&mut self) {
+        if !self.vhf_stop {
+            log::debug!("VHF cleanup on drop has been invoked for us.");
+
+            let stop_result = self.stop();
+            if stop_result.is_err() {
+                log::error!("VHF.stop had error during drop: {stop_result:?}");
+            }
+        }
+    }
+}
+
 pub struct VHFIter<'a> {
     /// non-iter parent
     vhf_parent: &'a VHF,

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -78,12 +78,9 @@ fn writes_correct_header() {
 
 #[test]
 fn creates_multiple_files() {
-    let scale_elements = 8;
-    let file_save_size = 2;
+    let scale_elements = 8; // scale number of generated elements
+    let file_save_size = 2; // scale number of elements in file
 
-    debug_assert!(
-        super::super::writer::FILE_LAZY_LEN < VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * file_save_size
-    );
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
@@ -124,7 +121,7 @@ fn creates_multiple_files() {
     let mut config = Configs::new(None).expect("Config struct could not be made");
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
     config.save_dir = (*tmp_dir.path()).into();
-    config.num_samples = VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * 2;
+    config.num_samples = VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * file_save_size;
     config.verbosity = 3;
     config.skip_num = i16::MAX as u16;
     let num_file = total_elements.div_ceil(config.num_samples);
@@ -149,6 +146,109 @@ fn creates_multiple_files() {
         std::fs::read_dir(config.save_dir).unwrap().count(),
         num_file
     );
+    tmp_dir.close().expect("Could not close temp_dir.");
+    push_arc_pages_thread.join().expect("Failed to join");
+}
+
+/// There was a deadlock in creating a new file on the 7th gen intel machine
+#[ignore = "large files"]
+#[test]
+fn creates_correct_multithreaded_files() {
+    let scale_elements = 2usize.pow(15); // scale number of generated elements
+    let file_save_size = 2usize.pow(14); // scale number of elements in file
+
+    debug_assert!(
+        super::super::writer::FILE_LAZY_LEN < VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * file_save_size
+    );
+    let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
+    log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
+    let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
+    let (mut debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+
+    let total_elements = total_window_len * MMAP_PAGE_LEN;
+    let StreamFold::None(params) = StreamFold::none_default() else {
+        log::error!("Nonoverlapping windows are not StreamFold::None variant.");
+        panic!()
+    };
+
+    // Define the signal we are testing for.
+    let ampl = 5000f64;
+    let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
+    let phase_offset = 1.2f64;
+    let signal_radius = 5000f64;
+
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (
+            ampl,
+            ang_freq,
+            phase_offset,
+            signal_radius,
+            TAU * 0x7FFF as f64,
+        ),
+    );
+    let _signal_expected = signal.clone(); // This will lose the engine
+
+    let thread_sleep = Duration::new(0, 10_000);
+    // We want the vhf thread to keep up with arc_pages_thread
+    debug_vhf.time_between_pages = thread_sleep.try_into().unwrap();
+
+    // Add signal into pages. We now add data into the buffer.
+    let push_arc_pages_thread =
+        push_arc_pages(dbg_vhf_buffer, signal, thread_sleep, eng).expect("push_arc_pages failed");
+
+    let time_start = Zoned::now();
+    let mut config = Configs::new(None).expect("Config struct could not be made");
+    let tmp_dir = TempDir::new().expect("Could not create temp_dir");
+    config.save_dir = (*tmp_dir.path()).into();
+    config.num_samples = VHF_MMAP_WINDOW_LEN * MMAP_PAGE_LEN * file_save_size;
+    config.verbosity = 3;
+    config.skip_num = i16::MAX as u16;
+    let num_file = total_elements.div_ceil(config.num_samples);
+    log::info!("save_dir = {:?}", &config.save_dir);
+    log::info!("num_files = {:?}", &num_file);
+    log::info!(
+        "num_samples = {:?}, this translates to {:?} MiB",
+        &config.num_samples,
+        &config.num_samples * 8 / 2usize.pow(20)
+    );
+    debug_assert!(
+        num_file >= 2,
+        "Point of this test is ensuring file writer does not lock up"
+    );
+    config.num_files = num_file;
+    let phasemeter_kwargs = HashMap::from([(
+        CString::new("tmp_laser").unwrap(),
+        CString::new("2").unwrap(),
+    )]);
+
+    config.phasemeter_kwargs = phasemeter_kwargs;
+
+    // Pull out from buffer and write to file in multithreaded
+    let mut writer = V1Writer::new(&config, time_start);
+    let vhf_iter = debug_vhf.iter();
+    use pariter::IteratorExt;
+    let body = pariter::scope(|scope| {
+        vhf_iter
+            .step_by(params.step_by)
+            .parallel_map_scoped(scope, |x| (*params.func)(x))
+            .try_for_each(|write_block| writer.write_data(write_block))
+            .expect("Failed to write data");
+    });
+
+    match body {
+        Ok(_) => log::info!("Run completed"),
+        Err(e) => log::error!("Main loop occurred with error = {:?}", e),
+    };
+
+    // Check that this is a correct number of files.
+    assert_eq!(
+        std::fs::read_dir(config.save_dir).unwrap().count(),
+        num_file
+    );
+
     tmp_dir.close().expect("Could not close temp_dir.");
     push_arc_pages_thread.join().expect("Failed to join");
 }

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -4,24 +4,26 @@ use super::super::config::Configs;
 use super::super::fold::StreamFold;
 use super::super::writer::{V1Writer, VHFWriter};
 use super::consts::MMAP_PAGE_LEN;
-use super::test_vhf::{create_arc_pages, debug_vhf_new};
+use super::test_vhf::{debug_vhf_new, push_arc_pages};
+use super::test_vhf_step_fold::SineArr;
 use super::*;
-use crate::types::Polar;
 
 use jiff::Zoned;
 use std::collections::HashMap;
 use std::f64::consts::TAU;
 use std::ffi::CString;
+use std::time::Duration;
 use tempfile::TempDir;
 use test_log::test;
 
 /// Write a file that has data with m-overflow.
-/// This test will fail if [super::test_vhf_step_fold::stepped_overlapping_identity_b] fails.
+/// This test will fail if [super::test_vhf_step_fold::stepped_nonoverlapping_identity_b] fails.
 #[test]
 fn writes_correct_header() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let StreamFold::None(params) = StreamFold::none_default() else {
@@ -33,29 +35,24 @@ fn writes_correct_header() {
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x + (TAU * 0x7FFF as f64),
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    };
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (
+            ampl,
+            ang_freq,
+            phase_offset,
+            signal_radius,
+            TAU * 0x7FFF as f64,
+        ),
+    );
+    let _signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::new(0, 100), eng)
+        .expect("push_arc_pages failed");
 
     let time_start = Zoned::now();
     let mut config = Configs::new(None).expect("Config struct could not be made");
@@ -76,6 +73,7 @@ fn writes_correct_header() {
     // TODO: Check for correctness of written data.
 
     tmp_dir.close().expect("Could not close temp_dir.");
+    push_arc_pages_thread.join().expect("Failed to join");
 }
 
 #[test]
@@ -89,7 +87,8 @@ fn creates_multiple_files() {
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let StreamFold::None(params) = StreamFold::none_default() else {
@@ -101,29 +100,25 @@ fn creates_multiple_files() {
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x + (TAU * 0x7FFF as f64),
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    };
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (
+            ampl,
+            ang_freq,
+            phase_offset,
+            signal_radius,
+            TAU * 0x7FFF as f64,
+        ),
+    );
+    let _signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    let push_arc_pages_thread =
+        push_arc_pages(dbg_vhf_buffer, signal, Duration::new(0, 10_000), eng)
+            .expect("push_arc_pages failed");
 
     let time_start = Zoned::now();
     let mut config = Configs::new(None).expect("Config struct could not be made");
@@ -155,4 +150,5 @@ fn creates_multiple_files() {
         num_file
     );
     tmp_dir.close().expect("Could not close temp_dir.");
+    push_arc_pages_thread.join().expect("Failed to join");
 }

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -4,7 +4,11 @@ use super::*;
 use crate::types::RawVHFWord;
 
 use heapless::Deque;
-use std::{matches, ops::Deref};
+use std::{
+    matches,
+    ops::Deref,
+    sync::atomic::{AtomicU64, Ordering},
+};
 use tempfile::{NamedTempFile, TempDir};
 use test_log::test;
 
@@ -43,6 +47,39 @@ pub(super) fn debug_vhf_new(total_to_read: NonZeroUsize) -> VHF {
         time_between_pages,
         wake_mmap,
         total_pages_to_read: total_to_read,
+    }
+}
+
+// Generate the zero-constant iterator on demand.
+struct ZeroArr {
+    total_len: AtomicU64,
+    current_idx: AtomicU64,
+    engine_running: Arc<AtomicBool>,
+}
+
+impl Iterator for ZeroArr {
+    type Item = RawVHFWord;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+            self.engine_running.fetch_and(false, Ordering::AcqRel);
+            None
+        } else {
+            self.current_idx.fetch_add(1, Ordering::Relaxed);
+            Some(0)
+        }
+    }
+}
+
+impl ZeroArr {
+    fn new(total_len: usize, engine_running: Arc<AtomicBool>) -> Self {
+        if total_len % MMAP_PAGE_LEN != 0 {
+            log::warn!("ZeroArr did not receive an integer multiple of MMAP_PAGE_LEN");
+        }
+        Self {
+            total_len: AtomicU64::new(total_len as u64),
+            current_idx: AtomicU64::new(0),
+            engine_running,
+        }
     }
 }
 
@@ -107,6 +144,37 @@ fn vhf_drops_arc() {
 
     // Check that content has been dropped.
     assert_eq!(to_drop.strong_count(), 0);
+}
+
+struct LinearArr {
+    total_len: AtomicU64,
+    current_idx: AtomicU64,
+    engine_running: Arc<AtomicBool>,
+}
+
+impl Iterator for LinearArr {
+    type Item = RawVHFWord;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+            self.engine_running.fetch_and(false, Ordering::AcqRel);
+            None
+        } else {
+            Some(self.current_idx.fetch_add(1, Ordering::AcqRel))
+        }
+    }
+}
+
+impl LinearArr {
+    fn new(total_len: usize, engine_running: Arc<AtomicBool>) -> Self {
+        if total_len % MMAP_PAGE_LEN != 0 {
+            log::warn!("LinearArr did not receive an integer multiple of MMAP_PAGE_LEN");
+        }
+        Self {
+            total_len: AtomicU64::new(total_len as u64),
+            current_idx: AtomicU64::new(0),
+            engine_running,
+        }
+    }
 }
 
 /// We check that the VHF struct is yielding the correct windows with next.

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -8,12 +8,15 @@ use std::{
     matches,
     ops::Deref,
     sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
 };
 use tempfile::{NamedTempFile, TempDir};
 use test_log::test;
 
 // Create a VHF struct with false child thread "map_reader".
-pub(super) fn debug_vhf_new(total_to_read: NonZeroUsize) -> VHF {
+pub(super) fn debug_vhf_new(
+    total_to_read: NonZeroUsize,
+) -> (VHF, Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>, Arc<AtomicBool>) {
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
     let raw_tmp_file = NamedTempFile::new_in(tmp_dir).expect("Could not create temp file");
 
@@ -25,29 +28,72 @@ pub(super) fn debug_vhf_new(total_to_read: NonZeroUsize) -> VHF {
     let raw_handle = raw_tmp_file.into_file();
     let map_reader = thread::Builder::new()
         .name("false_reader".to_string())
-        .spawn(|| {
-            return Ok(());
-        })
+        .spawn(|| Ok(()))
         .expect("map_reader could not be spawned.");
-    let engine_running = Arc::new(AtomicBool::new(false));
+    let engine_running = Arc::new(AtomicBool::new(true));
     let buffer_signal = Arc::new(Condvar::new());
     let buffer = Arc::new(Mutex::new(Deque::new()));
-    let time_between_pages = Span::new();
+    // Nonzero amount of time so that signal can also acquire Mutex
+    let time_between_pages = Span::new()
+        .try_milliseconds(1)
+        .expect("Failed to make time_between_pages");
     let wake_mmap = Arc::new(RwLock::new(Instant::now()));
 
-    VHF {
-        configuration: Box::new(configuration),
-        handle,
-        raw_handle,
-        map_reader,
-        engine_running,
-        vhf_stop: false,
-        buffer_signal,
+    (
+        VHF {
+            configuration: Box::new(configuration),
+            handle,
+            raw_handle,
+            map_reader,
+            engine_running: Arc::clone(&engine_running),
+            vhf_stop: false,
+            buffer_signal,
+            buffer: Arc::clone(&buffer),
+            time_between_pages,
+            wake_mmap,
+            total_pages_to_read: total_to_read,
+        },
         buffer,
-        time_between_pages,
-        wake_mmap,
-        total_pages_to_read: total_to_read,
-    }
+        engine_running,
+    )
+}
+
+/// Pushes [pages::Page]s from slice into [VHF].buffer.
+pub(super) fn push_arc_pages(
+    buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    data: impl Iterator<Item = RawVHFWord> + Send + 'static,
+    sleep_between_pages: Duration,
+    engine: Arc<AtomicBool>,
+) -> Result<JoinHandle<()>> {
+    thread::Builder::new()
+        .name("Unit Test: Buffer Page Creator".to_string())
+        .spawn(move || {
+            use itertools::Itertools;
+            data.into_iter()
+                .chunks(MMAP_PAGE_LEN)
+                .into_iter()
+                .map(|x| x.collect_array().unwrap())
+                .map(Arc::new)
+                .map(MmapPage::Page)
+                .for_each(|x| {
+                    'try_lock: loop {
+                        if let Ok(mut buf) = buffer.try_lock()
+                        // Obtain lock here so that parent thread still obtain lock.
+                        {
+                            buf.push_back(x).expect("Failed to push back onto buffer");
+                            break 'try_lock;
+                        } else {
+                            log::debug!("failed to obtain lock to push onto buffer, trying again");
+                            thread::sleep(sleep_between_pages / 100);
+                            continue 'try_lock;
+                        };
+                    }
+                    thread::sleep(sleep_between_pages);
+                });
+            // Set to false if Iterator has not already done so.
+            engine.fetch_and(false, Ordering::AcqRel);
+        })
+        .map_err(Error::Io)
 }
 
 // Generate the zero-constant iterator on demand.
@@ -83,52 +129,31 @@ impl ZeroArr {
     }
 }
 
-/// Create [pages::Page]s from slice.
-pub(super) fn create_arc_pages(data: &[RawVHFWord]) -> Vec<MmapPage> {
-    let data_len = data.len();
-    if data_len % MMAP_PAGE_LEN != 0 {
-        log::warn!("create_arc_pages did not receive an integer multiple of MMAP_PAGE_LEN");
-    }
-    let mut result = Vec::with_capacity(data_len / MMAP_PAGE_LEN);
-
-    use itertools::Itertools;
-    data.iter()
-        .chunks(MMAP_PAGE_LEN)
-        .into_iter()
-        .map(|x| x.copied().collect_array().unwrap())
-        .map(Arc::new)
-        .map(MmapPage::Page)
-        .for_each(|x| result.push(x));
-
-    result
-}
-
 /// We check if the iterator method does drop the Arc when .iter() has completed consuming.
 #[test]
 fn vhf_drops_arc() {
     let debug_vhf_total_len = 1;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     // We now add a weakpointer to the first object.
     let testing_page = Arc::new([0; MMAP_PAGE_LEN]);
     let to_drop = Arc::downgrade(&testing_page);
 
     // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        buf.push_back(MmapPage::Page(testing_page))
-            .expect("Push back failed.");
-        (1..total_window_len).for_each(|_| {
-            create_arc_pages(&[0; MMAP_PAGE_LEN])
-                .into_iter()
-                .for_each(|x| {
-                    buf.push_back(x).expect("Push back failed");
-                })
-        });
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    }
+    dbg_vhf_buffer
+        .try_lock()
+        .expect("Failed to lock buffer")
+        .push_back(MmapPage::Page(testing_page))
+        .expect("Failed to push_back testing page.");
+    let push_arc_pages_thread = push_arc_pages(
+        dbg_vhf_buffer,
+        ZeroArr::new((total_window_len - 1) * MMAP_PAGE_LEN, eng.clone()),
+        Duration::default(),
+        eng,
+    )
+    .expect("push_arc_pages failed");
 
     // Pull out the first window, and check that content of the window is as expected.
     {
@@ -144,6 +169,8 @@ fn vhf_drops_arc() {
 
     // Check that content has been dropped.
     assert_eq!(to_drop.strong_count(), 0);
+
+    push_arc_pages_thread.join().expect("Failed to join");
 }
 
 struct LinearArr {
@@ -182,22 +209,15 @@ impl LinearArr {
 fn next_window_linear() {
     let debug_vhf_total_len = 5;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN - 1;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     // Define the signal that we are testing for. (Use linear so its easier to determine.)
-    let signal = 0..((total_window_len * MMAP_PAGE_LEN) as RawVHFWord);
+    let signal = LinearArr::new(total_window_len * MMAP_PAGE_LEN, eng.clone());
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        let tmp_signal: Vec<_> = signal.clone().collect();
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    };
+    // Add signal into pages. We now add data into the buffer.
+    push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+        .expect("push_arc_pages failed");
 
     let mut debug_vhf_iter = debug_vhf.iter();
     for _ in 0..debug_vhf_total_len {

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -7,7 +7,7 @@ use heapless::Deque;
 use std::{
     matches,
     ops::Deref,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
     time::Duration,
 };
 use tempfile::{NamedTempFile, TempDir};
@@ -98,15 +98,15 @@ pub(super) fn push_arc_pages(
 
 // Generate the zero-constant iterator on demand.
 struct ZeroArr {
-    total_len: AtomicU64,
-    current_idx: AtomicU64,
+    total_len: usize,
+    current_idx: AtomicUsize,
     engine_running: Arc<AtomicBool>,
 }
 
 impl Iterator for ZeroArr {
     type Item = RawVHFWord;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len {
             self.engine_running.fetch_and(false, Ordering::AcqRel);
             None
         } else {
@@ -122,8 +122,8 @@ impl ZeroArr {
             log::warn!("ZeroArr did not receive an integer multiple of MMAP_PAGE_LEN");
         }
         Self {
-            total_len: AtomicU64::new(total_len as u64),
-            current_idx: AtomicU64::new(0),
+            total_len,
+            current_idx: AtomicUsize::new(0),
             engine_running,
         }
     }
@@ -174,7 +174,7 @@ fn vhf_drops_arc() {
 }
 
 struct LinearArr {
-    total_len: AtomicU64,
+    total_len: u64,
     current_idx: AtomicU64,
     engine_running: Arc<AtomicBool>,
 }
@@ -182,7 +182,7 @@ struct LinearArr {
 impl Iterator for LinearArr {
     type Item = RawVHFWord;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len {
             self.engine_running.fetch_and(false, Ordering::AcqRel);
             None
         } else {
@@ -197,7 +197,7 @@ impl LinearArr {
             log::warn!("LinearArr did not receive an integer multiple of MMAP_PAGE_LEN");
         }
         Self {
-            total_len: AtomicU64::new(total_len as u64),
+            total_len: total_len.try_into().unwrap(),
             current_idx: AtomicU64::new(0),
             engine_running,
         }

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -11,7 +11,78 @@ use super::*;
 use crate::types::{IQMTriplet, Polar, RawVHFWord};
 
 use std::f64::consts::{PI, TAU};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use test_log::test;
+
+pub(super) struct SineArr {
+    total_len: AtomicUsize,
+    current_idx: AtomicUsize,
+    engine_running: Arc<AtomicBool>,
+    phase_ampl: f64,
+    phase_angular_frequency: f64,
+    phase_offset: f64,
+    signal_ampl: f64,
+    phase_y_offset: f64,
+}
+
+impl Iterator for SineArr {
+    type Item = RawVHFWord;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+            self.engine_running.fetch_and(false, Ordering::AcqRel);
+            None
+        } else {
+            let i = self.current_idx.fetch_add(1, Ordering::Acquire);
+            let p = Polar {
+                radius: self.signal_ampl,
+                phase: (i as f64)
+                    .mul_add(self.phase_angular_frequency, self.phase_offset)
+                    .sin()
+                    .mul_add(self.phase_ampl, self.phase_y_offset),
+            };
+            Some(p.into())
+        }
+    }
+}
+
+impl SineArr {
+    /// Create a new iterator that generates a sine function.
+    /// Parameters:
+    /// * `total_len`: How many elements the iterator should yield.
+    /// * `engine_running`: For this iterator to stop the VHF engine when the thread spawned by
+    ///   this function ends.
+    /// * `params`: (phase_ampl, phase_angular_frequency, phase_offset, signal_ampl, y-offset)
+    pub(super) fn new(
+        total_len: usize,
+        engine_running: Arc<AtomicBool>,
+        params: (f64, f64, f64, f64, f64),
+    ) -> Self {
+        if total_len % MMAP_PAGE_LEN != 0 {
+            log::warn!("ZeroArr did not receive an integer multiple of MMAP_PAGE_LEN");
+        }
+        Self {
+            total_len: AtomicUsize::new(total_len),
+            current_idx: AtomicUsize::new(0),
+            engine_running,
+            phase_ampl: params.0,
+            phase_angular_frequency: params.1,
+            phase_offset: params.2,
+            signal_ampl: params.3,
+            phase_y_offset: params.4,
+        }
+    }
+}
+
+impl Clone for SineArr {
+    fn clone(&self) -> Self {
+        Self {
+            total_len: AtomicUsize::new(self.total_len.load(Ordering::Acquire)),
+            current_idx: AtomicUsize::new(self.current_idx.load(Ordering::Acquire)),
+            engine_running: Arc::new(AtomicBool::new(false)),
+            ..*self
+        }
+    }
+}
 
 /// Check that without any m-overflow, StreamFold behaves to expectation.
 #[test]

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -6,12 +6,13 @@
 
 use super::super::fold::StreamFold;
 use super::consts::MMAP_PAGE_LEN;
-use super::test_vhf::{create_arc_pages, debug_vhf_new};
+use super::test_vhf::{debug_vhf_new, push_arc_pages};
 use super::*;
 use crate::types::{IQMTriplet, Polar, RawVHFWord};
 
 use std::f64::consts::{PI, TAU};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use test_log::test;
 
 pub(super) struct SineArr {
@@ -89,7 +90,8 @@ impl Clone for SineArr {
 fn stepped_nonoverlapping_identity_a() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let StreamFold::None(params) = StreamFold::none_default() else {
@@ -101,29 +103,18 @@ fn stepped_nonoverlapping_identity_a() {
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x,
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    };
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (ampl, ang_freq, phase_offset, signal_radius, 0.),
+    );
+    let signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+        .expect("push_arc_pages failed");
 
     let result: Vec<RawVHFWord> = debug_vhf
         .iter()
@@ -132,7 +123,7 @@ fn stepped_nonoverlapping_identity_a() {
         .flat_map(|x| x.data.into_iter())
         .collect();
 
-    let expected: Vec<RawVHFWord> = signal.map(|x| x.into()).collect();
+    let expected: Vec<RawVHFWord> = signal_expected.collect();
 
     assert_eq!(result.len(), expected.len());
     result.into_iter().zip(expected).for_each(|(r, e)| {
@@ -142,6 +133,8 @@ fn stepped_nonoverlapping_identity_a() {
         assert_eq!(rq, eq);
         assert_eq!(rm, em);
     });
+
+    push_arc_pages_thread.join().expect("Failed to join");
 }
 
 /// Check that with any m-overflow, StreamFold behaves to expectation.
@@ -149,7 +142,8 @@ fn stepped_nonoverlapping_identity_a() {
 fn stepped_nonoverlapping_identity_b() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     let StreamFold::None(params) = StreamFold::none_default() else {
@@ -161,29 +155,24 @@ fn stepped_nonoverlapping_identity_b() {
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x + (TAU * 0x7FFF as f64),
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
-    } else {
-        log::error!("Could not get log in debug_vhf.buffer");
-        panic!();
-    };
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (
+            ampl,
+            ang_freq,
+            phase_offset,
+            signal_radius,
+            TAU * 0x7FFF as f64,
+        ),
+    );
+    let signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+        .expect("push_arc_pages failed");
 
     let result: Vec<RawVHFWord> = debug_vhf
         .iter()
@@ -192,7 +181,7 @@ fn stepped_nonoverlapping_identity_b() {
         .flat_map(|x| x.data.into_iter())
         .collect();
 
-    let expected: Vec<RawVHFWord> = signal.map(|x| x.into()).collect();
+    let expected: Vec<RawVHFWord> = signal_expected.map(|x| x.into()).collect();
 
     assert_eq!(result.len(), expected.len());
     result.into_iter().zip(expected).for_each(|(r, e)| {
@@ -202,6 +191,8 @@ fn stepped_nonoverlapping_identity_b() {
         assert_eq!(rq, eq);
         assert_eq!(rm, em);
     });
+
+    push_arc_pages_thread.join().expect("Failed to join");
 }
 
 /// Check that without any m-overflow, StreamFold behaves to expectation.
@@ -214,37 +205,34 @@ fn stepped_overlapping_identity_a() {
 
     let debug_vhf_total_len = 4 * params.step_by;
     let total_window_len = debug_vhf_total_len + params.step_by;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
     let total_elements = total_window_len * MMAP_PAGE_LEN;
 
     // Define the signal we are testing for.
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x,
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        buf.push_back(MmapPage::Empty).expect("Push back failed.");
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (ampl, ang_freq, phase_offset, signal_radius, 0.),
+    );
+    let signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    if let Ok(mut buf) = dbg_vhf_buffer.try_lock() {
+        (0..params.pad).map(|_| MmapPage::Empty).for_each(|page| {
+            buf.push_back(page).expect("failed to push_back empty");
+        });
     } else {
-        log::error!("Could not get log in debug_vhf.buffer");
+        log::warn!("failed to lock buf");
         panic!();
     };
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+        .expect("push_arc_pages failed");
 
     // We also need to test for sign overflow.
     let results: Vec<_> = debug_vhf
@@ -259,7 +247,7 @@ fn stepped_overlapping_identity_a() {
         .collect();
     let result_overflow_idx: Vec<_> = results.into_iter().flat_map(|x| x.overflow()).collect();
 
-    let expected_phase: Vec<RawVHFWord> = signal.map(|x| x.into()).collect();
+    let expected_phase: Vec<RawVHFWord> = signal_expected.collect();
     let expected_overflow_idx: Vec<(usize, i8)> = Vec::new();
 
     assert_eq!(result_phase.len(), expected_phase.len());
@@ -275,6 +263,8 @@ fn stepped_overlapping_identity_a() {
         });
 
     assert_eq!(result_overflow_idx.len(), expected_overflow_idx.len());
+
+    push_arc_pages_thread.join().expect("Failed to join");
 }
 
 /// Check that with m-overflow, StreamFold behaves to expectation.
@@ -286,7 +276,8 @@ fn stepped_overlapping_identity_b() {
     };
 
     let total_window_len = params.step_by;
-    let debug_vhf = debug_vhf_new(NonZeroUsize::new(total_window_len).unwrap());
+    let (debug_vhf, dbg_vhf_buffer, eng) =
+        debug_vhf_new(NonZeroUsize::new(total_window_len).unwrap());
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     log::info!("total_elements = {}", total_elements);
 
@@ -294,30 +285,32 @@ fn stepped_overlapping_identity_b() {
     let ampl = 5000f64;
     let ang_freq = TAU / (MMAP_PAGE_LEN as f64 / 2. + 1.);
     let phase_offset = 1.2f64;
-    let signal_phase =
-        (0..total_elements).map(|i| ampl * (i as f64).mul_add(ang_freq, phase_offset).sin());
     let signal_radius = 5000f64;
-    let signal = signal_phase.map(|x| Polar {
-        radius: signal_radius,
-        phase: x + (TAU * 0x7FFF as f64),
-    });
 
-    // Add signal into pages.
-    // We now add data into the buffer.
-    if let Ok(mut buf) = debug_vhf.buffer.lock() {
-        buf.push_back(MmapPage::Empty).expect("Push back failed.");
-        let tmp_signal: Vec<_> = signal.clone().map(|x| x.into()).collect();
-        log::info!(
-            "Number of pages placed into buffer = {}",
-            create_arc_pages(&tmp_signal).len()
-        );
-        create_arc_pages(&tmp_signal)
-            .into_iter()
-            .for_each(|x| buf.push_back(x).expect("Push back failed."));
+    let signal = SineArr::new(
+        total_elements,
+        eng.clone(),
+        (
+            ampl,
+            ang_freq,
+            phase_offset,
+            signal_radius,
+            TAU * 0x7FFF as f64,
+        ),
+    );
+    let signal_expected = signal.clone(); // This will lose the engine
+
+    // Add signal into pages. We now add data into the buffer.
+    if let Ok(mut buf) = dbg_vhf_buffer.try_lock() {
+        (0..params.pad).map(|_| MmapPage::Empty).for_each(|page| {
+            buf.push_back(page).expect("failed to push_back empty");
+        });
     } else {
-        log::error!("Could not get log in debug_vhf.buffer");
+        log::warn!("failed to lock buf");
         panic!();
     };
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+        .expect("push_arc_pages failed");
 
     // We also need to test for sign overflow.
     let results: Vec<_> = debug_vhf
@@ -332,7 +325,7 @@ fn stepped_overlapping_identity_b() {
         .collect();
     let result_overflow_idx: Vec<_> = results.into_iter().flat_map(|x| x.overflow()).collect();
 
-    let expected_phase: Vec<RawVHFWord> = signal.map(|x| x.into()).collect();
+    let expected_phase: Vec<RawVHFWord> = signal_expected.collect();
     let expected_overflow_idx: Vec<(usize, i8)> = {
         // + signs
         let plus = (1..)
@@ -350,6 +343,7 @@ fn stepped_overlapping_identity_b() {
     };
 
     {
+        log::info!("result_overflow_idx[0] = {:?}", result_overflow_idx.first());
         let (i, sign) = result_overflow_idx.first().unwrap();
         let show: Vec<IQMTriplet> = (i - 1..=i + 1).map(|i| result_phase[i].into()).collect();
         log::info!(
@@ -379,4 +373,6 @@ fn stepped_overlapping_identity_b() {
         });
 
     assert_eq!(result_overflow_idx, expected_overflow_idx);
+
+    push_arc_pages_thread.join().expect("Failed to join");
 }

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use test_log::test;
 
 pub(super) struct SineArr {
-    total_len: AtomicUsize,
+    total_len: usize,
     current_idx: AtomicUsize,
     engine_running: Arc<AtomicBool>,
     phase_ampl: f64,
@@ -29,7 +29,7 @@ pub(super) struct SineArr {
 impl Iterator for SineArr {
     type Item = RawVHFWord;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_idx.load(Ordering::Acquire) >= self.total_len.load(Ordering::Acquire) {
+        if self.current_idx.load(Ordering::Acquire) >= self.total_len {
             self.engine_running.fetch_and(false, Ordering::AcqRel);
             None
         } else {
@@ -62,7 +62,7 @@ impl SineArr {
             log::warn!("ZeroArr did not receive an integer multiple of MMAP_PAGE_LEN");
         }
         Self {
-            total_len: AtomicUsize::new(total_len),
+            total_len,
             current_idx: AtomicUsize::new(0),
             engine_running,
             phase_ampl: params.0,
@@ -75,9 +75,9 @@ impl SineArr {
 }
 
 impl Clone for SineArr {
+    /// XXX: This will detach from the [`engine_running`].
     fn clone(&self) -> Self {
         Self {
-            total_len: AtomicUsize::new(self.total_len.load(Ordering::Acquire)),
             current_idx: AtomicUsize::new(self.current_idx.load(Ordering::Acquire)),
             engine_running: Arc::new(AtomicBool::new(false)),
             ..*self

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -2,6 +2,8 @@
 
 use super::{FILE_LAZY_LEN, VHFWriter};
 use crate::{Error, Result, runner::Config, types::RawVHFWord};
+#[cfg(not(test))]
+use jiff::SignedDuration;
 use jiff::{Span, Zoned};
 use std::{
     fmt::Debug,
@@ -107,26 +109,36 @@ impl V1Writer {
             return Err(Error::InternalInconsistency);
         }
 
+        let file_time = self
+            .start_time
+            .checked_add(
+                self.num_files_so_far.load(Ordering::Acquire) as i64 * self.time_between_files,
+            )
+            .map_err(Error::Jiff)?;
         let path = {
             let mut tmp = self.file_dir.clone();
             // Since this function opens the file, we can take this as the offset.
-            let time = self
-                .start_time
-                .checked_add(
-                    self.num_files_so_far.load(Ordering::Acquire) as i64 * self.time_between_files,
-                )
-                .map_err(Error::Jiff)?;
             tmp.push(match self.filename_details.len() {
-                0 => time.strftime("%FT%T%.f%z").to_string() + ".bin",
+                0 => file_time.strftime("%FT%T%.f%z").to_string() + ".bin",
                 _ => format!(
                     "{}_{}.bin",
-                    time.strftime("%FT%T%.f%z"),
+                    file_time.strftime("%FT%T%.f%z"),
                     self.filename_details
                 ),
             });
             tmp
         };
 
+        #[cfg(not(test))]
+        {
+            let now = Zoned::now();
+            if file_time.duration_since(&now) > SignedDuration::new(10, 0)
+                || now.duration_since(&file_time) > SignedDuration::new(10, 0)
+            {
+                log::error!("Created file time differs significantly from current time!");
+                return Err(Error::InternalInconsistency);
+            }
+        }
         if std::fs::exists(path.clone()).unwrap() {
             log::error!(
                 "Created file name found to already exist in location, path = {:?}",

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -239,7 +239,7 @@ impl V1Writer {
                     .try_for_each(|word| file.write_u64::<LittleEndian>(word))
                     .map_err(Error::Io)?;
                 self.num_elements_written
-                    .fetch_add(buf_len, Ordering::Relaxed);
+                    .fetch_add(buf_len, Ordering::Release);
             };
             // Note! This can be be zero if the internal buffer was just nice the size
             // of the file.

--- a/VHF-rs/src/runner/writer/v1_writer.rs
+++ b/VHF-rs/src/runner/writer/v1_writer.rs
@@ -4,6 +4,7 @@ use super::{FILE_LAZY_LEN, VHFWriter};
 use crate::{Error, Result, runner::Config, types::RawVHFWord};
 use jiff::{Span, Zoned};
 use std::{
+    fmt::Debug,
     fs::{File, OpenOptions},
     io::BufWriter,
     path::PathBuf,
@@ -11,6 +12,7 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
+    thread,
 };
 
 const V1_MAGIC_HEADER: u64 = 0x123456ABCDEF0000;
@@ -70,10 +72,12 @@ impl VHFWriter for V1Writer {
                 self.write_data_passed_buffer(data)
             }?;
 
-            log::trace!(
-                "One round of drain occurred. Number of elements left = {}",
-                data.len()
-            );
+            if !data.is_empty() {
+                log::trace!(
+                    "One round of drain occurred with elements left = {}",
+                    data.len()
+                )
+            }
 
             // Check if to continue or break loop
             if self.num_elements_written.load(Ordering::Acquire) >= self.num_elements_per_file {
@@ -296,9 +300,33 @@ impl V1Writer {
 
 impl Drop for V1Writer {
     fn drop(&mut self) {
+        if thread::panicking() {
+            log::warn!("V1Writer in panic. self = {:?}", self);
+        }
+
         let tmp = self.close_file();
         if tmp.is_err() {
             log::warn!("Failed to close file during drop!");
         }
+    }
+}
+
+impl Debug for V1Writer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entry(&"files", &self.num_files_so_far)
+            .entry(&"files_tot", &self.num_files)
+            .entry(&"elements_written", &self.num_elements_written)
+            .entry(&"elements_tot", &self.num_elements_per_file)
+            .entry(
+                &"internal_buf_len",
+                &self
+                    .elements_to_write
+                    .try_lock()
+                    .and_then(|x| Ok((*x).len())),
+            )
+            .entry(&"file_dir", &self.file_dir)
+            // Don't really care for the internal headers etc as they are const
+            .finish()
     }
 }


### PR DESCRIPTION
This PR was made initially out of the attempt to fix what was initially assumed as
a deadlock in `v1_writer`. The following changes and fixes are thus made:

* Change logging level to be more consistent with better output.
* Fix VHF start not using high/low sampling speed.
* Change VHF struct unit tests to use streaming from an iterator.
* Fix not creating more than i32::MAX number of elements.