### PR TITLE
Change communication between MMapReader and VHF

### DIFF
--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -4,15 +4,14 @@
 //! the use of [mmap_thread].
 
 use super::super::fold::StreamFold;
-use super::{DEQUE_CAP, MMAP_BYTES_LEN, consts::MMAP_PAGE_LEN, pages::MmapPage};
+use super::{MMAP_BYTES_LEN, consts::MMAP_PAGE_LEN, pages::MmapPage};
 use crate::{Error, Result};
-use heapless::Deque;
 use jiff::Span;
 use mmap_rs::Mmap;
-use std::hint::spin_loop;
 use std::num::NonZeroUsize;
+use std::sync::mpsc::SyncSender;
 use std::sync::{
-    Arc, Condvar, Mutex, RwLock,
+    Arc, Condvar, RwLock,
     atomic::{self, AtomicBool},
 };
 use std::thread;
@@ -38,7 +37,7 @@ pub(super) struct MMapReader {
     /// iterator.
     // Strongly note that MMapPages are therefore fragmented with respect to each other, but we eat
     // this cost first.
-    transfer_buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    transfer_buffer_sender: SyncSender<MmapPage>,
     /// This is the tfb32 value from the last ioctl.
     last_tfb32: libc::c_int,
     /// This is the last index being read from.
@@ -66,7 +65,7 @@ impl MMapReader {
         mmap: Mmap,
         engine_running: Arc<AtomicBool>,
         transfer_buffer_signal: Arc<Condvar>,
-        transfer_buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+        transfer_buffer_sender: SyncSender<MmapPage>,
         time_between_mmap_page: &Span,
         time_between_stream_resume: Duration,
         next_collect_time: Arc<RwLock<Instant>>,
@@ -88,7 +87,7 @@ impl MMapReader {
             mmap,
             engine_running,
             transfer_buffer_signal,
-            transfer_buffer,
+            transfer_buffer_sender,
             last_tfb32: 0,
             prev_bytes: 0,
             page_duration: (*time_between_mmap_page).try_into().map_err(Error::Jiff)?,
@@ -174,47 +173,38 @@ impl MMapReader {
                 break 'next_mmap;
             }
 
-            // We deliberately do not fetch for a new value of ioctl whiles trying to get a
-            // mutex lock. (We will consider updating in the future if the try_lock takes too
-            // long.)
-            'push_back: loop {
-                match self.transfer_buffer.try_lock() {
-                    Err(_) => {
-                        log::trace!("could not get buffer for pushing onto page");
-                        spin_loop(); // This is a no-op on x86;
-                    }
-                    Ok(mut inner) => {
-                        use itertools::Itertools;
+            let mut num_pages = 0;
 
-                        let mut num_pages = 0;
+            let channel_push = {
+                use itertools::Itertools;
 
-                        self.get_mmap_iter(self.prev_bytes, next_bytes)
-                            .chunks(MMAP_PAGE_LEN)
-                            .into_iter()
-                            .map(|x| x.copied().collect_array().unwrap())
-                            .map(Arc::new)
-                            .map(MmapPage::Page)
-                            .for_each(|x| {
-                                num_pages += 1;
-                                (*inner).push_back(x).expect("Failed to push back.");
-                            });
+                self.get_mmap_iter(self.prev_bytes, next_bytes)
+                    .chunks(MMAP_PAGE_LEN)
+                    .into_iter()
+                    .map(|x| x.copied().collect_array().unwrap())
+                    .map(Arc::new)
+                    .map(MmapPage::Page)
+                    .try_for_each(|x| {
+                        num_pages += 1;
+                        self.transfer_buffer_sender.send(x)
+                    })
+            };
 
-                        // Update counter
-                        self.collected_pages += num_pages;
-                        self.prev_bytes = next_bytes;
+            // Update counter
+            self.collected_pages += num_pages;
+            self.prev_bytes = next_bytes;
 
-                        // Signal back to parent thread that pages have been placed in.
-                        self.transfer_buffer_signal.notify_all();
+            // Signal back to parent thread that pages have been placed in.
+            self.transfer_buffer_signal.notify_all();
 
-                        // Set next wake time again
-                        {
-                            let mut to_write = self.next_collect_time.write().unwrap();
-                            *to_write = Instant::now() + self.stream_pause;
-                        }
+            if channel_push.is_err() {
+                panic!("Channel from MMapReader to VHF was full");
+            }
 
-                        break 'push_back;
-                    }
-                };
+            // Set next wake time again
+            {
+                let mut to_write = self.next_collect_time.write().unwrap();
+                *to_write = Instant::now() + self.stream_pause;
             }
 
             // If number of pages read has exceeded break
@@ -251,16 +241,9 @@ impl MMapReader {
     fn pad_end(&self) -> Result<()> {
         let pad = self.pad_end_remaining();
         log::debug!("pad_end called with {} MMapPage::End to pad with", pad);
-        'push_back: loop {
-            match self.transfer_buffer.try_lock() {
-                Err(_) => spin_loop(),
-                Ok(mut inner) => {
-                    (0..pad)
-                        .for_each(|_| inner.push_back(MmapPage::End).expect("Failed to push_back"));
-                    break 'push_back;
-                }
-            };
-        }
+        (0..pad)
+            .try_for_each(|_| self.transfer_buffer_sender.send(MmapPage::End))
+            .expect("Failed to send");
         Ok(())
     }
 
@@ -294,7 +277,7 @@ pub(super) fn mmap_thread(
     mmap: Mmap,
     engine: Arc<AtomicBool>,
     buffer_signal: Arc<Condvar>,
-    buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    buffer_sender: SyncSender<MmapPage>,
     time_between_mmap_page: &Span,
     time_between_stream_resume: Duration,
     next_collect_time: Arc<RwLock<Instant>>,
@@ -306,7 +289,7 @@ pub(super) fn mmap_thread(
         mmap,
         engine,
         buffer_signal,
-        buffer,
+        buffer_sender,
         time_between_mmap_page,
         time_between_stream_resume,
         next_collect_time,

--- a/VHF-rs/src/runner/process/mmap_reader.rs
+++ b/VHF-rs/src/runner/process/mmap_reader.rs
@@ -267,7 +267,7 @@ impl MMapReader {
     /// Cleaning up before thread exits.
     fn close(&self) -> Result<()> {
         log::info!("MMapReader has been invoked to be closed");
-        self.engine_running.store(false, atomic::Ordering::Relaxed);
+        self.engine_running.store(false, atomic::Ordering::Release);
         Ok(())
     }
 }

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -39,7 +39,7 @@ pub struct VHF {
     /// map_reader contains the thread that is responsible for pulling elements out of the MMap
     /// into a [Self::buffer].
     /// More details is as given in [self::mmap_reader].
-    map_reader: JoinHandle<Result<()>>,
+    map_reader: Option<JoinHandle<Result<()>>>,
     /// Used to signal to [self::mmap_reader::MMapReader] has started, and to determine that child has stopped.
     engine_running: Arc<AtomicBool>,
     /// Stopped invoked
@@ -151,7 +151,7 @@ impl VHF {
             configuration: Box::new(config.clone()),
             handle,
             raw_handle,
-            map_reader,
+            map_reader: Some(map_reader),
             engine_running,
             vhf_stop: false,
             buffer_signal,
@@ -265,6 +265,21 @@ impl VHF {
         }
         self.vhf_stop = true;
 
+        if let Some(map) = self.map_reader.take() {
+            if !map.is_finished() {
+                log::warn!("MMapReader child thread not found to be exhausted.");
+                self.map_reader = Some(map); // Place back into struct.
+            } else {
+                if map.join().is_err() {
+                    log::warn!("MMapReader child thread found to have panicked.");
+                } else {
+                    log::debug!("MMapReader child thread closed successfully.")
+                }
+            }
+        } else {
+            log::warn!("MMapReader child thread not found. Was VHF already closed?");
+        }
+
         if self.engine_running.load(atomic::Ordering::Acquire) {
             log::warn!("Parent thread tried to close when engine has not shut down.");
             self.vhf_stop = false;
@@ -309,7 +324,7 @@ impl VHF {
     /// Unpark MMapReader thread
     #[inline]
     fn unpark_child(&self) {
-        self.map_reader.thread().unpark()
+        self.map_reader.as_ref().unwrap().thread().unpark()
     }
 }
 

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -17,11 +17,15 @@ use mmap_reader::mmap_thread;
 use mmap_rs::Mmap;
 use nix::fcntl;
 use pages::MmapPage;
+use std::cell::RefCell;
 use std::io::{BufWriter, Write};
 use std::num::NonZeroUsize;
+use std::rc::Rc;
+use std::sync::mpsc::TryRecvError;
 use std::sync::{
     Arc, Condvar, Mutex, RwLock,
     atomic::{self, AtomicBool},
+    mpsc::{Receiver, sync_channel},
 };
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -47,10 +51,12 @@ pub struct VHF {
     /// Used to receive signal from [self::mmap_reader::MMapReader] that new pages have been placed into
     /// [Self::buffer].
     buffer_signal: Arc<Condvar>,
+    /// This is the channel used to receive from the child thread.
+    buffer_receive: Receiver<MmapPage>,
     /// buffer is a local mirror of Mmap that is intended for the likes of SlidingWindow
     /// [itertools::Itertools::tuple_windows] and par_map, which has more Rust Semantics than reading straight
     /// out of a Mmap.
-    buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    buffer: Rc<RefCell<Deque<MmapPage, DEQUE_CAP>>>,
     /// This is the amount of time between any two pages. Used for determining other timings.
     time_between_pages: Span,
     /// Expected time when to next wake up mmap_reader thread.
@@ -105,15 +111,15 @@ impl VHF {
             (0..config.stream_fold.pad())
                 .try_for_each(|_| buffer.push_back(MmapPage::Empty))
                 .expect("Failed to push_back onto buffer.");
-            Arc::new(Mutex::new(buffer))
+            Rc::new(RefCell::new(buffer))
         };
         let buffer_signal = Arc::new(Condvar::new()); // merge into buffer?
+        let (buffer_producer, buffer_consumer) = sync_channel(DEQUE_CAP);
 
         let map_reader: JoinHandle<Result<()>> = {
             let readback = Self::readback_buffer(&raw_handle)?;
             let engine_running = engine_running.clone();
             let buffer_signal = buffer_signal.clone();
-            let buffer = buffer.clone();
             let number_of_pages_between_stream_resume = (VHF_MMAP_WINDOW_LEN as i64 - 4) * 3;
             let time_between_stream_resume = (number_of_pages_between_stream_resume
                 * time_between_pages)
@@ -133,7 +139,7 @@ impl VHF {
                         readback,
                         engine_running,
                         buffer_signal,
-                        buffer,
+                        buffer_producer,
                         &time_between_pages,
                         time_between_stream_resume,
                         next_collect_time,
@@ -155,6 +161,7 @@ impl VHF {
             engine_running,
             vhf_stop: false,
             buffer_signal,
+            buffer_receive: buffer_consumer,
             buffer,
             time_between_pages,
             wake_mmap,
@@ -313,8 +320,12 @@ impl VHF {
             vhf_parent: self,
             engine_running: &self.engine_running,
             buffer_signal: &self.buffer_signal,
-            buffer: &self.buffer,
-            time_between_pages: self.time_between_pages.try_into().expect("Failed to convert Span to Duration"),
+            buffer_receive: &self.buffer_receive,
+            buffer: Rc::clone(&self.buffer),
+            time_between_pages: self
+                .time_between_pages
+                .try_into()
+                .expect("Failed to convert Span to Duration"),
             wake_mmap: &self.wake_mmap,
             total_pages_to_read: self.total_pages_to_read,
             windows_released: 0,
@@ -349,10 +360,12 @@ pub struct VHFIter<'a> {
     /// Used to receive signal from [self::mmap_reader::MMapReader] that new pages have been placed into
     /// [self.buffer].
     buffer_signal: &'a Arc<Condvar>,
+    /// This is the channel used to receive from the child thread.
+    buffer_receive: &'a Receiver<MmapPage>,
     /// buffer is a local mirror of Mmap that is intended for the likes of SlidingWindow
     /// [itertools::Itertools::tuple_windows] and par_map, which has more Rust Semantics than reading straight
     /// out of a Mmap.
-    buffer: &'a Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    buffer: Rc<RefCell<Deque<MmapPage, DEQUE_CAP>>>,
     /// This is the amount of time between any two pages. Used for determining other timings.
     time_between_pages: Duration,
     /// Expected time when to next wake up mmap_reader thread.
@@ -400,25 +413,37 @@ impl std::iter::Iterator for VHFIter<'_> {
         let mg = Mutex::new(());
 
         'get_page: loop {
-            // Return first if there are more elements in the buffer
-            if let Ok(mut buf) = self.buffer.try_lock() {
-                // if length >> num_items then assign to variable, pop left most, and return
-                if buf.len() >= VHF_MMAP_WINDOW_LEN {
-                    let arr = buf
-                        .iter()
-                        .take(VHF_MMAP_WINDOW_LEN)
-                        .cloned()
-                        .collect_array()
-                        .unwrap();
-                    let idx = self.windows_released;
-                    self.windows_released += 1;
-                    let _ = buf.pop_front();
-                    return Some((idx, arr));
+            // Try fetch out from channel
+            match self.buffer_receive.try_recv() {
+                Ok(page) => {
+                    let result = self.buffer.borrow_mut().push_back(page);
+                    if result.is_err() {
+                        log::error!("Pushing onto internal buffer without sufficient space.");
+                        // Discard failed to push page.
+                    }
+                    continue 'get_page;
                 }
-            } else if self.buffer.is_poisoned() {
-                panic!("MMapReader thread has panicked");
-            }; // We do nothing even if buffer was not locked: Child thread might still be pushing
-            // into it.
+                Err(TryRecvError::Disconnected) => (), // Child thread has completed or panicked.
+                Err(TryRecvError::Empty) => (),        // Proceed to next step
+            }
+
+            // Return first if there are more elements in the buffer
+            // if length >> num_items then assign to variable, pop left most, and return
+
+            if self.buffer.borrow().len() >= VHF_MMAP_WINDOW_LEN {
+                let arr = self
+                    .buffer
+                    .borrow_mut()
+                    .iter()
+                    .take(VHF_MMAP_WINDOW_LEN)
+                    .cloned()
+                    .collect_array()
+                    .unwrap();
+                let idx = self.windows_released;
+                self.windows_released += 1;
+                let _ = self.buffer.borrow_mut().pop_front();
+                return Some((idx, arr));
+            }
 
             // Early break - Engine is not running anymore for any reason (Thread panic perhaps?)
             if !self

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -24,7 +24,7 @@ use std::sync::{
     atomic::{self, AtomicBool},
 };
 use std::thread::{self, JoinHandle};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// This is the size in bytes of the Mmap that is backed by the VHF device.
 const MMAP_BYTES_LEN: usize = 1 << 22;
@@ -314,7 +314,7 @@ impl VHF {
             engine_running: &self.engine_running,
             buffer_signal: &self.buffer_signal,
             buffer: &self.buffer,
-            time_between_pages: self.time_between_pages,
+            time_between_pages: self.time_between_pages.try_into().expect("Failed to convert Span to Duration"),
             wake_mmap: &self.wake_mmap,
             total_pages_to_read: self.total_pages_to_read,
             windows_released: 0,
@@ -354,7 +354,7 @@ pub struct VHFIter<'a> {
     /// out of a Mmap.
     buffer: &'a Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
     /// This is the amount of time between any two pages. Used for determining other timings.
-    time_between_pages: Span,
+    time_between_pages: Duration,
     /// Expected time when to next wake up mmap_reader thread.
     wake_mmap: &'a Arc<RwLock<Instant>>,
     /// This is the total number of pages to be read by [mmap_reader::MMapReader].
@@ -399,8 +399,6 @@ impl std::iter::Iterator for VHFIter<'_> {
         // WARN: Mutex creation every time next method is called.
         let mg = Mutex::new(());
 
-        let time_between_pages = self.time_between_pages.try_into().unwrap();
-
         'get_page: loop {
             // Return first if there are more elements in the buffer
             if let Ok(mut buf) = self.buffer.try_lock() {
@@ -436,7 +434,7 @@ impl std::iter::Iterator for VHFIter<'_> {
             // 1. Condvar activated or
             // 2. We self check that the current instant exceeds the time as a last measure.
 
-            thread::sleep(time_between_pages);
+            thread::sleep(self.time_between_pages);
             'get_wake: loop {
                 if let Ok(target_wakeup) = self.wake_mmap.read() {
                     let target_wakeup = *target_wakeup;
@@ -450,7 +448,7 @@ impl std::iter::Iterator for VHFIter<'_> {
                         // Wait 1 page of time for condvar
                         let timeout = self
                             .buffer_signal
-                            .wait_timeout(mg.lock().unwrap(), time_between_pages)
+                            .wait_timeout(mg.lock().unwrap(), self.time_between_pages)
                             .unwrap();
                         if !timeout.1.timed_out() {
                             // Forcibly try to get a page

--- a/VHF-rs/src/runner/process/test_v1_write.rs
+++ b/VHF-rs/src/runner/process/test_v1_write.rs
@@ -22,7 +22,7 @@ use test_log::test;
 fn writes_correct_header() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
@@ -51,7 +51,7 @@ fn writes_correct_header() {
     let _signal_expected = signal.clone(); // This will lose the engine
 
     // Add signal into pages. We now add data into the buffer.
-    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::new(0, 100), eng)
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_sender, signal, Duration::new(0, 100), eng)
         .expect("push_arc_pages failed");
 
     let time_start = Zoned::now();
@@ -84,7 +84,7 @@ fn creates_multiple_files() {
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
@@ -114,7 +114,7 @@ fn creates_multiple_files() {
 
     // Add signal into pages. We now add data into the buffer.
     let push_arc_pages_thread =
-        push_arc_pages(dbg_vhf_buffer, signal, Duration::new(0, 10_000), eng)
+        push_arc_pages(dbg_vhf_sender, signal, Duration::new(0, 10_000), eng)
             .expect("push_arc_pages failed");
 
     let time_start = Zoned::now();
@@ -163,7 +163,7 @@ fn creates_correct_multithreaded_files() {
     let debug_vhf_total_len = VHF_MMAP_WINDOW_LEN * scale_elements;
     log::info!("debug_vhf_total_len = {}", &debug_vhf_total_len);
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (mut debug_vhf, dbg_vhf_buffer, eng) =
+    let (mut debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
@@ -197,7 +197,7 @@ fn creates_correct_multithreaded_files() {
 
     // Add signal into pages. We now add data into the buffer.
     let push_arc_pages_thread =
-        push_arc_pages(dbg_vhf_buffer, signal, thread_sleep, eng).expect("push_arc_pages failed");
+        push_arc_pages(dbg_vhf_sender, signal, thread_sleep, eng).expect("push_arc_pages failed");
 
     let time_start = Zoned::now();
     let mut config = Configs::new(None).expect("Config struct could not be made");

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -7,7 +7,10 @@ use heapless::Deque;
 use std::{
     matches,
     ops::Deref,
-    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        mpsc::{SyncSender, sync_channel},
+    },
     time::Duration,
 };
 use tempfile::{NamedTempFile, TempDir};
@@ -16,7 +19,7 @@ use test_log::test;
 // Create a VHF struct with false child thread "map_reader".
 pub(super) fn debug_vhf_new(
     total_to_read: NonZeroUsize,
-) -> (VHF, Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>, Arc<AtomicBool>) {
+) -> (VHF, SyncSender<MmapPage>, Arc<AtomicBool>) {
     let tmp_dir = TempDir::new().expect("Could not create temp_dir");
     let raw_tmp_file = NamedTempFile::new_in(tmp_dir).expect("Could not create temp file");
 
@@ -32,7 +35,8 @@ pub(super) fn debug_vhf_new(
         .expect("map_reader could not be spawned.");
     let engine_running = Arc::new(AtomicBool::new(true));
     let buffer_signal = Arc::new(Condvar::new());
-    let buffer = Arc::new(Mutex::new(Deque::new()));
+    let (buffer_sender, buffer_receive) = sync_channel(DEQUE_CAP);
+    let buffer = Rc::new(RefCell::new(Deque::new()));
     // Nonzero amount of time so that signal can also acquire Mutex
     let time_between_pages = Span::new()
         .try_milliseconds(1)
@@ -48,19 +52,20 @@ pub(super) fn debug_vhf_new(
             engine_running: Arc::clone(&engine_running),
             vhf_stop: false,
             buffer_signal,
-            buffer: Arc::clone(&buffer),
+            buffer_receive,
+            buffer,
             time_between_pages,
             wake_mmap,
             total_pages_to_read: total_to_read,
         },
-        buffer,
+        buffer_sender,
         engine_running,
     )
 }
 
 /// Pushes [pages::Page]s from slice into [VHF].buffer.
 pub(super) fn push_arc_pages(
-    buffer: Arc<Mutex<Deque<MmapPage, DEQUE_CAP>>>,
+    buffer_sender: SyncSender<MmapPage>,
     data: impl Iterator<Item = RawVHFWord> + Send + 'static,
     sleep_between_pages: Duration,
     engine: Arc<AtomicBool>,
@@ -76,18 +81,9 @@ pub(super) fn push_arc_pages(
                 .map(Arc::new)
                 .map(MmapPage::Page)
                 .for_each(|x| {
-                    'try_lock: loop {
-                        if let Ok(mut buf) = buffer.try_lock()
-                        // Obtain lock here so that parent thread still obtain lock.
-                        {
-                            buf.push_back(x).expect("Failed to push back onto buffer");
-                            break 'try_lock;
-                        } else {
-                            log::debug!("failed to obtain lock to push onto buffer, trying again");
-                            thread::sleep(sleep_between_pages / 100);
-                            continue 'try_lock;
-                        };
-                    }
+                    buffer_sender
+                        .send(x)
+                        .expect("Failed to push back onto buffer");
                     thread::sleep(sleep_between_pages);
                 });
             // Set to false if Iterator has not already done so.
@@ -134,7 +130,7 @@ impl ZeroArr {
 fn vhf_drops_arc() {
     let debug_vhf_total_len = 1;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     // We now add a weakpointer to the first object.
@@ -142,13 +138,11 @@ fn vhf_drops_arc() {
     let to_drop = Arc::downgrade(&testing_page);
 
     // We now add data into the buffer.
-    dbg_vhf_buffer
-        .try_lock()
-        .expect("Failed to lock buffer")
-        .push_back(MmapPage::Page(testing_page))
+    dbg_vhf_sender
+        .send(MmapPage::Page(testing_page))
         .expect("Failed to push_back testing page.");
     let push_arc_pages_thread = push_arc_pages(
-        dbg_vhf_buffer,
+        dbg_vhf_sender,
         ZeroArr::new((total_window_len - 1) * MMAP_PAGE_LEN, eng.clone()),
         Duration::default(),
         eng,
@@ -209,14 +203,14 @@ impl LinearArr {
 fn next_window_linear() {
     let debug_vhf_total_len = 5;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN - 1;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     // Define the signal that we are testing for. (Use linear so its easier to determine.)
     let signal = LinearArr::new(total_window_len * MMAP_PAGE_LEN, eng.clone());
 
     // Add signal into pages. We now add data into the buffer.
-    push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+    push_arc_pages(dbg_vhf_sender, signal, Duration::default(), eng)
         .expect("push_arc_pages failed");
 
     let mut debug_vhf_iter = debug_vhf.iter();

--- a/VHF-rs/src/runner/process/test_vhf.rs
+++ b/VHF-rs/src/runner/process/test_vhf.rs
@@ -44,7 +44,7 @@ pub(super) fn debug_vhf_new(
             configuration: Box::new(configuration),
             handle,
             raw_handle,
-            map_reader,
+            map_reader: Some(map_reader),
             engine_running: Arc::clone(&engine_running),
             vhf_stop: false,
             buffer_signal,

--- a/VHF-rs/src/runner/process/test_vhf_step_fold.rs
+++ b/VHF-rs/src/runner/process/test_vhf_step_fold.rs
@@ -90,7 +90,7 @@ impl Clone for SineArr {
 fn stepped_nonoverlapping_identity_a() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
@@ -113,7 +113,7 @@ fn stepped_nonoverlapping_identity_a() {
     let signal_expected = signal.clone(); // This will lose the engine
 
     // Add signal into pages. We now add data into the buffer.
-    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_sender, signal, Duration::default(), eng)
         .expect("push_arc_pages failed");
 
     let result: Vec<RawVHFWord> = debug_vhf
@@ -142,7 +142,7 @@ fn stepped_nonoverlapping_identity_a() {
 fn stepped_nonoverlapping_identity_b() {
     let debug_vhf_total_len = 4 * VHF_MMAP_WINDOW_LEN;
     let total_window_len = debug_vhf_total_len + VHF_MMAP_WINDOW_LEN;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
 
     let total_elements = total_window_len * MMAP_PAGE_LEN;
@@ -171,7 +171,7 @@ fn stepped_nonoverlapping_identity_b() {
     let signal_expected = signal.clone(); // This will lose the engine
 
     // Add signal into pages. We now add data into the buffer.
-    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_sender, signal, Duration::default(), eng)
         .expect("push_arc_pages failed");
 
     let result: Vec<RawVHFWord> = debug_vhf
@@ -205,7 +205,7 @@ fn stepped_overlapping_identity_a() {
 
     let debug_vhf_total_len = 4 * params.step_by;
     let total_window_len = debug_vhf_total_len + params.step_by;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(debug_vhf_total_len).unwrap());
     let total_elements = total_window_len * MMAP_PAGE_LEN;
 
@@ -223,15 +223,11 @@ fn stepped_overlapping_identity_a() {
     let signal_expected = signal.clone(); // This will lose the engine
 
     // Add signal into pages. We now add data into the buffer.
-    if let Ok(mut buf) = dbg_vhf_buffer.try_lock() {
-        (0..params.pad).map(|_| MmapPage::Empty).for_each(|page| {
-            buf.push_back(page).expect("failed to push_back empty");
-        });
-    } else {
-        log::warn!("failed to lock buf");
-        panic!();
-    };
-    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+    (0..params.pad)
+        .map(|_| MmapPage::Empty)
+        .try_for_each(|page| dbg_vhf_sender.send(page))
+        .expect("failed to push_back empty");
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_sender, signal, Duration::default(), eng)
         .expect("push_arc_pages failed");
 
     // We also need to test for sign overflow.
@@ -276,7 +272,7 @@ fn stepped_overlapping_identity_b() {
     };
 
     let total_window_len = params.step_by;
-    let (debug_vhf, dbg_vhf_buffer, eng) =
+    let (debug_vhf, dbg_vhf_sender, eng) =
         debug_vhf_new(NonZeroUsize::new(total_window_len).unwrap());
     let total_elements = total_window_len * MMAP_PAGE_LEN;
     log::info!("total_elements = {}", total_elements);
@@ -301,15 +297,11 @@ fn stepped_overlapping_identity_b() {
     let signal_expected = signal.clone(); // This will lose the engine
 
     // Add signal into pages. We now add data into the buffer.
-    if let Ok(mut buf) = dbg_vhf_buffer.try_lock() {
-        (0..params.pad).map(|_| MmapPage::Empty).for_each(|page| {
-            buf.push_back(page).expect("failed to push_back empty");
-        });
-    } else {
-        log::warn!("failed to lock buf");
-        panic!();
-    };
-    let push_arc_pages_thread = push_arc_pages(dbg_vhf_buffer, signal, Duration::default(), eng)
+    (0..params.pad)
+        .map(|_| MmapPage::Empty)
+        .try_for_each(|page| dbg_vhf_sender.send(page))
+        .expect("failed to push_back empty");
+    let push_arc_pages_thread = push_arc_pages(dbg_vhf_sender, signal, Duration::default(), eng)
         .expect("push_arc_pages failed");
 
     // We also need to test for sign overflow.


### PR DESCRIPTION
Previously, there was lock contention between child MMapReader thread and VHF parent thread.
By using channels, lock contention can be removed.
However, it is not as obvious from the parent thread if child thread has panicked.

Also, it's still abit of a struggle sharing the buffer between parent and iter(child) struct, as parent
struct is responsible for pushing empty pages; while child struct pushes regular pages.