### PR TITLE
Seperate file writing into its own thread

### DIFF
--- a/VHF-rs/src/bin/stream.rs
+++ b/VHF-rs/src/bin/stream.rs
@@ -1,11 +1,21 @@
 use pariter::IteratorExt;
 use std::path::PathBuf;
-use vhf::Result;
+use std::sync::mpsc::{Receiver, channel};
+use std::thread;
 use vhf::runner::{
     Config, VHF,
     fold::StreamFold,
-    writer::{V1Writer, VHFWriter},
+    writer::{V1Writer, VHFWriter, WriteBlock},
 };
+use vhf::{Error, Result};
+
+fn writer_thread(consumer: Receiver<WriteBlock>, mut file_writer: V1Writer) {
+    // try_recv will sleep when empty
+    while let Ok(words) = consumer.recv() {
+        file_writer.write_data(words).expect("failed to write");
+    }
+    file_writer.close().expect("Failed to close file_writer");
+}
 
 fn main() -> Result<()> {
     let _ = log4rs::init_file("log4rs.yml", Default::default()).expect("log4rs.yml not found!"); // Logger init
@@ -16,18 +26,24 @@ fn main() -> Result<()> {
     let mut vhf = VHF::new(&conf, &params)?;
     let time_start = vhf.start()?;
 
-    let file_writer = &mut V1Writer::new(&conf, time_start);
+    let file_writer = V1Writer::new(&conf, time_start);
     let StreamFold::Map(params) = params else {
         log::error!("Overlapping windows are not StreamFold::Map variant.");
         panic!()
     };
+
+    let (writer_send, writer_receive) = channel();
+    let writer_thread = thread::Builder::new()
+        .name("File Writer".to_string())
+        .spawn(move || writer_thread(writer_receive, file_writer))
+        .map_err(Error::Io)?;
 
     let vhf_iter = vhf.iter();
     let body = pariter::scope(|scope| {
         vhf_iter
             .step_by(params.step_by)
             .parallel_map_scoped(scope, |x| (*params.func)(x))
-            .try_for_each(|write_block| file_writer.write_data(write_block))
+            .try_for_each(|write_block| writer_send.send(write_block))
             .expect("Failed to write data");
     });
 
@@ -39,7 +55,9 @@ fn main() -> Result<()> {
     // VHF cleanup
     vhf.stop()?;
 
-    file_writer.close()?;
+    // File writer clean up
+    drop(writer_send);
+    writer_thread.join().expect("Could not close writer thread");
 
     Ok(())
 }

--- a/VHF-rs/src/runner/process/mod.rs
+++ b/VHF-rs/src/runner/process/mod.rs
@@ -21,7 +21,6 @@ use std::cell::RefCell;
 use std::io::{BufWriter, Write};
 use std::num::NonZeroUsize;
 use std::rc::Rc;
-use std::sync::mpsc::TryRecvError;
 use std::sync::{
     Arc, Condvar, Mutex, RwLock,
     atomic::{self, AtomicBool},
@@ -413,18 +412,13 @@ impl std::iter::Iterator for VHFIter<'_> {
         let mg = Mutex::new(());
 
         'get_page: loop {
-            // Try fetch out from channel
-            match self.buffer_receive.try_recv() {
-                Ok(page) => {
-                    let result = self.buffer.borrow_mut().push_back(page);
-                    if result.is_err() {
-                        log::error!("Pushing onto internal buffer without sufficient space.");
-                        // Discard failed to push page.
-                    }
-                    continue 'get_page;
+            // Try non-blocking fetch out from channel
+            while let Ok(page) = self.buffer_receive.try_recv() {
+                let result = self.buffer.borrow_mut().push_back(page);
+                if result.is_err() {
+                    log::error!("Pushing onto internal buffer without sufficient space.");
+                    // Discard failed to push page.
                 }
-                Err(TryRecvError::Disconnected) => (), // Child thread has completed or panicked.
-                Err(TryRecvError::Empty) => (),        // Proceed to next step
             }
 
             // Return first if there are more elements in the buffer
@@ -433,7 +427,7 @@ impl std::iter::Iterator for VHFIter<'_> {
             if self.buffer.borrow().len() >= VHF_MMAP_WINDOW_LEN {
                 let arr = self
                     .buffer
-                    .borrow_mut()
+                    .borrow()
                     .iter()
                     .take(VHF_MMAP_WINDOW_LEN)
                     .cloned()


### PR DESCRIPTION
Contrary to commit message, it has been determined that it prior to the change of file writing into its own thread,
the FIFO buffer on the FPGA was in fact only clearing at the rate of USB2.0 speeds, and so, a fresh read of an already
overflowing buffer was unlikely to crash the process.
The differing timing between the file write and expected write time is currently the only way the process tracks that there is any issue.