### PR TITLE
Fix force flag of clear-fifo not used

### DIFF
--- a/VHF-rs/src/bin/clear-fifo.rs
+++ b/VHF-rs/src/bin/clear-fifo.rs
@@ -229,7 +229,7 @@ fn main() -> Result<()> {
     };
 
     for board in boards {
-        clear_fifo_per_board(board, true)?;
+        clear_fifo_per_board(board, cli.force)?;
     }
 
     println!();


### PR DESCRIPTION
Minor bug where hybrid clear was invoked all the time even without `-f`

Note that this is changed from `-a` in the Python version.